### PR TITLE
Adds DataCollector policy to be able to disable the collection of Rum data

### DIFF
--- a/packages/rum_sdk/lib/rum_flutter.dart
+++ b/packages/rum_sdk/lib/rum_flutter.dart
@@ -5,6 +5,7 @@ import 'package:flutter/cupertino.dart';
 
 import 'package:rum_sdk/rum_native_methods.dart';
 import 'package:rum_sdk/rum_sdk.dart';
+import 'package:rum_sdk/src/data_collection_policy.dart';
 import 'package:rum_sdk/src/transport/batch_transport.dart';
 import 'package:rum_sdk/src/transport/rum_base_transport.dart';
 import 'package:rum_sdk/src/util/generate_session.dart';
@@ -26,6 +27,15 @@ class RumFlutter {
 
   @visibleForTesting
   static set instance(RumFlutter instance) => _instance = instance;
+
+  bool get enableDataCollection => DataCollectionPolicy().isEnabled;
+  set enableDataCollection(bool enable) {
+    if (enable) {
+      DataCollectionPolicy().enable();
+    } else {
+      DataCollectionPolicy().disable();
+    }
+  }
 
   RumConfig? config;
   List<BaseTransport> _transports = [];

--- a/packages/rum_sdk/lib/src/data_collection_policy.dart
+++ b/packages/rum_sdk/lib/src/data_collection_policy.dart
@@ -1,0 +1,24 @@
+import 'dart:developer';
+
+class DataCollectionPolicy {
+  static final DataCollectionPolicy _instance = DataCollectionPolicy._();
+
+  DataCollectionPolicy._();
+
+  factory DataCollectionPolicy() {
+    return _instance;
+  }
+
+  bool _isEnabled = true;
+  bool get isEnabled => _isEnabled;
+
+  void enable() {
+    log('Enabling data collection');
+    _isEnabled = true;
+  }
+
+  void disable() {
+    log('Disabling data collection');
+    _isEnabled = false;
+  }
+}

--- a/packages/rum_sdk/lib/src/models/user.dart
+++ b/packages/rum_sdk/lib/src/models/user.dart
@@ -3,7 +3,7 @@ class User {
   String? username;
   String? email;
 
-  User({this.id,  this.username, this.email});
+  User({this.id, this.username, this.email});
 
   User.fromJson(dynamic json) {
     id = json['id'];

--- a/packages/rum_sdk/lib/src/transport/rum_transport.dart
+++ b/packages/rum_sdk/lib/src/transport/rum_transport.dart
@@ -2,6 +2,7 @@ import 'dart:async';
 import 'dart:convert';
 import 'dart:developer';
 import 'package:http/http.dart' as http;
+import 'package:rum_sdk/src/data_collection_policy.dart';
 import 'package:rum_sdk/src/transport/rum_base_transport.dart';
 import 'package:rum_sdk/src/transport/task_buffer.dart';
 import 'package:rum_sdk/src/models/payload.dart';
@@ -23,6 +24,11 @@ class RUMTransport extends BaseTransport {
 
   @override
   Future<void> send(Payload payload) async {
+    if (DataCollectionPolicy().isEnabled == false) {
+      log('Data collection is disabled. Skipping sending data.');
+      return;
+    }
+
     final sessionId = this.sessionId;
 
     final headers = {

--- a/packages/rum_sdk/pubspec.yaml
+++ b/packages/rum_sdk/pubspec.yaml
@@ -4,12 +4,12 @@ description: A new Flutter plugin project.
 version: 1.0.0
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: ">=3.0.0 <4.0.0"
   flutter: ">=3.0.0"
 
 dependencies:
   plugin_platform_interface: ^2.0.2
-  package_info_plus: ^6.0.0
+  package_info_plus: ^8.0.1
   uuid: ^4.1.0
   intl: ^0.19.0
 
@@ -22,7 +22,6 @@ dev_dependencies:
 #  mockito: ^5.4.4
 
 flutter:
-
   plugin:
     platforms:
       android:
@@ -36,4 +35,3 @@ flutter:
         pluginClass: RumSdkPlugin
       windows:
         pluginClass: RumSdkPluginCApi
-


### PR DESCRIPTION
This is sort of a temp solution. I just wanted to get this in there so that we can feature toggle the Faro Rum while testing it out in our flutter application. 