### PR TITLE
Adds timestamp to measurment and adds lifecycle events

### DIFF
--- a/packages/rum_sdk/example/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/packages/rum_sdk/example/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -6,12 +6,14 @@ import FlutterMacOS
 import Foundation
 
 import connectivity_plus
+import device_info_plus
 import package_info_plus
 import path_provider_foundation
 import rum_sdk
 
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   ConnectivityPlusPlugin.register(with: registry.registrar(forPlugin: "ConnectivityPlusPlugin"))
+  DeviceInfoPlusMacosPlugin.register(with: registry.registrar(forPlugin: "DeviceInfoPlusMacosPlugin"))
   FPPPackageInfoPlusPlugin.register(with: registry.registrar(forPlugin: "FPPPackageInfoPlusPlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   RumSdkPlugin.register(with: registry.registrar(forPlugin: "RumSdkPlugin"))

--- a/packages/rum_sdk/example/pubspec.lock
+++ b/packages/rum_sdk/example/pubspec.lock
@@ -89,6 +89,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.10"
+  device_info_plus:
+    dependency: transitive
+    description:
+      name: device_info_plus
+      sha256: a7fd703482b391a87d60b6061d04dfdeab07826b96f9abd8f5ed98068acc0074
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.2"
+  device_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: device_info_plus_platform_interface
+      sha256: "282d3cf731045a2feb66abfe61bbc40870ae50a3ed10a4d3d217556c35c8c2ba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   fake_async:
     dependency: transitive
     description:
@@ -105,6 +121,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  file:
+    dependency: transitive
+    description:
+      name: file
+      sha256: "5fc22d7c25582e38ad9a8515372cd9a93834027aacf1801cf01164dac0ffa08c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   fixnum:
     dependency: transitive
     description:
@@ -172,18 +196,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -212,18 +236,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   nm:
     dependency: transitive
     description:
@@ -243,18 +267,18 @@ packages:
     dependency: transitive
     description:
       name: package_info_plus
-      sha256: cb44f49b6e690fa766f023d5b22cac6b9affe741dd792b6ac7ad4fabe0d7b097
+      sha256: a75164ade98cb7d24cfd0a13c6408927c6b217fa60dee5a7ff5c116a58f28918
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "8.0.2"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: "9bc8ba46813a4cc42c66ab781470711781940780fd8beddd0c3da62506d3a6c6"
+      sha256: ac1f4a4847f1ade8e6a87d1f39f5d7c67490738642e2542f559ec38c37489a66
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   path:
     dependency: transitive
     description:
@@ -399,10 +423,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   typed_data:
     dependency: transitive
     description:
@@ -431,10 +455,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
   web:
     dependency: transitive
     description:
@@ -451,6 +475,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.4.0"
+  win32_registry:
+    dependency: transitive
+    description:
+      name: win32_registry
+      sha256: "10589e0d7f4e053f2c61023a31c9ce01146656a70b7b7f0828c0b46d7da2a9bb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
   xdg_directories:
     dependency: transitive
     description:

--- a/packages/rum_sdk/lib/rum_flutter.dart
+++ b/packages/rum_sdk/lib/rum_flutter.dart
@@ -45,7 +45,7 @@ class RumFlutter {
   List<BaseTransport> get transports => _transports;
 
   Meta meta = Meta(
-      session: Session(generateSessionID()),
+      session: Session(generateSessionID(), attributes: {}),
       sdk: Sdk("rum-flutter", "1.3.5", []),
       app: App("", "", ""),
       view: ViewMeta("default"));

--- a/packages/rum_sdk/lib/rum_flutter.dart
+++ b/packages/rum_sdk/lib/rum_flutter.dart
@@ -7,6 +7,7 @@ import 'package:flutter/cupertino.dart';
 import 'package:rum_sdk/rum_native_methods.dart';
 import 'package:rum_sdk/rum_sdk.dart';
 import 'package:rum_sdk/src/data_collection_policy.dart';
+import 'package:rum_sdk/src/models/session_attributes.dart';
 import 'package:rum_sdk/src/transport/batch_transport.dart';
 import 'package:rum_sdk/src/transport/rum_base_transport.dart';
 import 'package:rum_sdk/src/util/generate_session.dart';
@@ -44,11 +45,7 @@ class RumFlutter {
   List<BaseTransport> get transports => _transports;
 
   Meta meta = Meta(
-      session: Session(generateSessionID(), attributes: {
-        "device": Platform.operatingSystem,
-        "device_version": Platform.operatingSystemVersion,
-        "dart_version": Platform.version
-      }),
+      session: Session(generateSessionID()),
       sdk: Sdk("rum-flutter", "1.3.5", []),
       app: App("", "", ""),
       view: ViewMeta("default"));
@@ -75,6 +72,8 @@ class RumFlutter {
   }
 
   Future<void> init({required RumConfig optionsConfiguration}) async {
+    meta.session?.attributes = await SessionAttributes().getAttributes();
+
     _nativeChannel ??= RumNativeMethods();
     config = optionsConfiguration;
     _batchTransport = _batchTransport ??

--- a/packages/rum_sdk/lib/src/integrations/flutter_error_integration.dart
+++ b/packages/rum_sdk/lib/src/integrations/flutter_error_integration.dart
@@ -1,27 +1,29 @@
 import 'package:flutter/foundation.dart';
 import 'package:rum_sdk/rum_flutter.dart';
 
-
-class FlutterErrorIntegration{
+class FlutterErrorIntegration {
   FlutterExceptionHandler? _defaultOnError;
 
   FlutterExceptionHandler? _onErrorIntegration;
 
-  void call(){
+  void call() {
     _defaultOnError = FlutterError.onError;
     _onErrorIntegration = (FlutterErrorDetails details) async {
-      if(details.stack !=null){
-        RumFlutter().pushError(type:"flutter_error",value: details.exceptionAsString(),stacktrace: details.stack);
+      if (details.stack != null) {
+        RumFlutter().pushError(
+            type: "flutter_error",
+            value: details.exceptionAsString(),
+            stacktrace: details.stack);
       }
 
-      if(_defaultOnError !=null){
+      if (_defaultOnError != null) {
         _defaultOnError?.call(details);
       }
     };
     FlutterError.onError = _onErrorIntegration;
-
   }
-  void close(){
+
+  void close() {
     FlutterError.onError = _defaultOnError;
   }
 }

--- a/packages/rum_sdk/lib/src/models/exception.dart
+++ b/packages/rum_sdk/lib/src/models/exception.dart
@@ -2,17 +2,17 @@ import 'dart:convert';
 import 'dart:core';
 import 'package:intl/intl.dart';
 
-class StackFrames{
-  int colno=0;
-  int lineno=0;
-  String filename="";
-  String function="";
-  StackFrames(this.filename,this.function,this.lineno,this.colno);
+class StackFrames {
+  int colno = 0;
+  int lineno = 0;
+  String filename = "";
+  String function = "";
+  StackFrames(this.filename, this.function, this.lineno, this.colno);
   StackFrames.fromJson(dynamic json) {
-    colno= json['colno'] ;
-    lineno= json['lineno'];
-    filename= json['filename'];
-    function = json['function']; 
+    colno = json['colno'];
+    lineno = json['lineno'];
+    filename = json['filename'];
+    function = json['function'];
   }
   Map<String, dynamic> toJson() {
     final map = <String, dynamic>{};
@@ -23,17 +23,18 @@ class StackFrames{
     map['function'] = function;
     return map;
   }
-
 }
+
 class RumException {
   String type = "";
   String value = "";
-  Map<String,dynamic> stacktrace = {};
+  Map<String, dynamic> stacktrace = {};
   String trace = "";
-  Map<String,String>? context = {};
-  String timestamp = DateFormat('yyyy-MM-dd\'T\'HH:mm:ss.SSS\'Z\'').format(DateTime.now().toUtc());
+  Map<String, String>? context = {};
+  String timestamp = DateFormat('yyyy-MM-dd\'T\'HH:mm:ss.SSS\'Z\'')
+      .format(DateTime.now().toUtc());
 
-  RumException(this.type, this.value, this.stacktrace,{this.context});
+  RumException(this.type, this.value, this.stacktrace, {this.context});
 
   RumException.fromJson(dynamic json) {
     type = json['type'];
@@ -54,21 +55,24 @@ class RumException {
     return map;
   }
 
-  static List<Map<String,dynamic>> stackTraceParse(StackTrace stacktrace) {
+  static List<Map<String, dynamic>> stackTraceParse(StackTrace stacktrace) {
     LineSplitter ls = LineSplitter();
     List<String> stackFrames = ls.convert(stacktrace.toString());
-    List<Map<String,dynamic>> parsedStackFrames = [];
+    List<Map<String, dynamic>> parsedStackFrames = [];
     for (final stackFrame in stackFrames) {
-      List<String> sf =stackFrame.split(" ");
-      const pattern = ".*((?<module>[a-zA-Z]*):(?<filename>[a-zA-Z-_/.]*):(?<lineno>[0-9]*):(?<colno>[0-9]*)).*";
+      List<String> sf = stackFrame.split(" ");
+      const pattern =
+          ".*((?<module>[a-zA-Z]*):(?<filename>[a-zA-Z-_/.]*):(?<lineno>[0-9]*):(?<colno>[0-9]*)).*";
       final regExp = RegExp(pattern);
-      RegExpMatch? regExpMatch = regExp.firstMatch(sf[sf.length-1]);
-      final filename = "${regExpMatch?.namedGroup("module")}:${regExpMatch?.namedGroup("filename")}";
+      RegExpMatch? regExpMatch = regExp.firstMatch(sf[sf.length - 1]);
+      final filename =
+          "${regExpMatch?.namedGroup("module")}:${regExpMatch?.namedGroup("filename")}";
       final lineno = regExpMatch?.namedGroup("lineno");
       final colno = regExpMatch?.namedGroup("colno");
-      parsedStackFrames.add(StackFrames(filename, sf[sf.length-2], int.parse(lineno ?? "0"), int.parse(colno ?? "0")).toJson());
+      parsedStackFrames.add(StackFrames(filename, sf[sf.length - 2],
+              int.parse(lineno ?? "0"), int.parse(colno ?? "0"))
+          .toJson());
     }
     return parsedStackFrames;
   }
-
 }

--- a/packages/rum_sdk/lib/src/models/measurement.dart
+++ b/packages/rum_sdk/lib/src/models/measurement.dart
@@ -1,18 +1,24 @@
-class Measurement {
-  Map<String,dynamic>?  values;
-  String type="";
+import 'package:intl/intl.dart';
 
-  Measurement(this.values,this.type);
+class Measurement {
+  Map<String, dynamic>? values;
+  String type = "";
+  String timestamp = DateFormat('yyyy-MM-dd\'T\'HH:mm:ss.SSS\'Z\'')
+      .format(DateTime.now().toUtc());
+
+  Measurement(this.values, this.type);
 
   Measurement.fromJson(dynamic json) {
     values = json['values'];
     type = json['type'];
+    timestamp = json['timestamp'];
   }
 
   Map<String, dynamic> toJson() {
     final map = <String, dynamic>{};
     map['values'] = values;
     map['type'] = type;
+    map['timestamp'] = timestamp;
     return map;
   }
 }

--- a/packages/rum_sdk/lib/src/models/session_attributes.dart
+++ b/packages/rum_sdk/lib/src/models/session_attributes.dart
@@ -1,0 +1,54 @@
+import 'dart:io';
+
+import 'package:device_info_plus/device_info_plus.dart';
+
+class SessionAttributes {
+  Future<Map<String, dynamic>> getAttributes() async {
+    final dartVersion = Platform.version;
+    String deviceOs = Platform.operatingSystem;
+    String deviceOsVersion = Platform.operatingSystemVersion;
+    String deviceOsDetail = "unknown";
+    String deviceManufacturer = "unknown";
+    String deviceModel = "unknown";
+    String deviceBrand = "unknown";
+    bool deviceIsPhysical = true;
+
+    if (Platform.isAndroid) {
+      var androidInfo = await DeviceInfoPlugin().androidInfo;
+      var release = androidInfo.version.release;
+      var sdkInt = androidInfo.version.sdkInt;
+
+      deviceOs = "Android";
+      deviceOsVersion = release;
+      deviceOsDetail = "Android $release (SDK $sdkInt)";
+      deviceManufacturer = androidInfo.manufacturer;
+      deviceModel = androidInfo.model;
+      deviceBrand = androidInfo.brand;
+      deviceIsPhysical = androidInfo.isPhysicalDevice;
+    }
+
+    if (Platform.isIOS) {
+      var iosInfo = await DeviceInfoPlugin().iosInfo;
+      deviceOs = iosInfo.systemName;
+      deviceOsVersion = iosInfo.systemVersion;
+      deviceOsDetail = "$deviceOs $deviceOsVersion";
+      deviceManufacturer = "apple";
+      deviceModel = iosInfo.utsname.machine;
+      deviceBrand = iosInfo.model;
+      deviceIsPhysical = iosInfo.isPhysicalDevice;
+    }
+
+    final attributes = <String, dynamic>{
+      "dart_version": dartVersion,
+      "device_os": deviceOs,
+      "device_os_version": deviceOsVersion,
+      "device_os_detail": deviceOsDetail,
+      "device_manufacturer": deviceManufacturer,
+      "device_model": deviceModel,
+      "device_brand": deviceBrand,
+      "device_is_physical": deviceIsPhysical,
+    };
+
+    return attributes;
+  }
+}

--- a/packages/rum_sdk/lib/src/models/session_attributes.dart
+++ b/packages/rum_sdk/lib/src/models/session_attributes.dart
@@ -3,7 +3,7 @@ import 'dart:io';
 import 'package:device_info_plus/device_info_plus.dart';
 
 class SessionAttributes {
-  Future<Map<String, dynamic>> getAttributes() async {
+  Future<Map<String, String>> getAttributes() async {
     final dartVersion = Platform.version;
     String deviceOs = Platform.operatingSystem;
     String deviceOsVersion = Platform.operatingSystemVersion;
@@ -38,7 +38,7 @@ class SessionAttributes {
       deviceIsPhysical = iosInfo.isPhysicalDevice;
     }
 
-    final attributes = <String, dynamic>{
+    final attributes = <String, String>{
       "dart_version": dartVersion,
       "device_os": deviceOs,
       "device_os_version": deviceOsVersion,
@@ -46,7 +46,7 @@ class SessionAttributes {
       "device_manufacturer": deviceManufacturer,
       "device_model": deviceModel,
       "device_brand": deviceBrand,
-      "device_is_physical": deviceIsPhysical,
+      "device_is_physical": '$deviceIsPhysical',
     };
 
     return attributes;

--- a/packages/rum_sdk/lib/src/rum_navigation_observer.dart
+++ b/packages/rum_sdk/lib/src/rum_navigation_observer.dart
@@ -1,32 +1,34 @@
 import 'package:flutter/widgets.dart';
 import 'package:rum_sdk/rum_sdk.dart';
 
-class RumNavigationObserver extends RouteObserver<PageRoute<dynamic>>{
-@override
+class RumNavigationObserver extends RouteObserver<PageRoute<dynamic>> {
+  @override
   void didPop(Route route, Route? previousRoute) {
-  super.didPop(route, previousRoute);
-  RumFlutter().setViewMeta(name:previousRoute?.settings.name);
-  RumFlutter().pushEvent("view_changed",attributes: {
-    "route":previousRoute?.settings.name
-  });
+    super.didPop(route, previousRoute);
+    RumFlutter().setViewMeta(name: previousRoute?.settings.name);
+    RumFlutter().pushEvent("view_changed", attributes: {
+      "fromView": route.settings.name,
+      "toView": previousRoute?.settings.name,
+    });
   }
-
 
   @override
   void didPush(Route route, Route? previousRoute) {
     super.didPush(route, previousRoute);
-    RumFlutter().setViewMeta(name:route.settings.name);
-    RumFlutter().pushEvent("view_changed",attributes: {
-      "route":route.settings.name
+    RumFlutter().setViewMeta(name: route.settings.name);
+    RumFlutter().pushEvent("view_changed", attributes: {
+      "fromView": previousRoute?.settings.name,
+      "toView": route.settings.name,
     });
-
   }
+
   @override
   void didReplace({Route? newRoute, Route? oldRoute}) {
-    super.didReplace(newRoute:newRoute, oldRoute:oldRoute);
+    super.didReplace(newRoute: newRoute, oldRoute: oldRoute);
     RumFlutter().setViewMeta(name: newRoute?.settings.name!);
-    RumFlutter().pushEvent("view_changed",attributes: {
-      "route":newRoute?.settings.name
+    RumFlutter().pushEvent("view_changed", attributes: {
+      "fromView": oldRoute?.settings.name,
+      "toView": newRoute?.settings.name,
     });
   }
 }

--- a/packages/rum_sdk/lib/src/rum_widgets_binding_observer.dart
+++ b/packages/rum_sdk/lib/src/rum_widgets_binding_observer.dart
@@ -2,20 +2,23 @@ import 'package:flutter/cupertino.dart';
 import 'package:rum_sdk/src/integrations/native_integration.dart';
 import 'package:rum_sdk/rum_sdk.dart';
 
-class RumWidgetsBindingObserver extends WidgetsBindingObserver{
+class RumWidgetsBindingObserver extends WidgetsBindingObserver {
+  AppLifecycleState? _previousState;
+
   @override
   void didChangeAppLifecycleState(AppLifecycleState state) {
     super.didChangeAppLifecycleState(state);
-    if(state==AppLifecycleState.resumed){
+    if (state == AppLifecycleState.resumed) {
       WidgetsBinding.instance!.addPostFrameCallback((timeStamp) {
         NativeIntegration.instance.getWarmStart();
       });
       NativeIntegration.instance.setWarmStart();
     }
-  }
-  @override
-  void didHaveMemoryPressure() {
-    super.didHaveMemoryPressure();
-  }
 
+    RumFlutter().pushEvent("app_lifecycle_changed", attributes: {
+      "fromState": _previousState?.name ?? '',
+      "toState": state.name,
+    });
+    _previousState = state;
+  }
 }

--- a/packages/rum_sdk/pubspec.lock
+++ b/packages/rum_sdk/pubspec.lock
@@ -169,6 +169,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.6"
+  device_info_plus:
+    dependency: "direct main"
+    description:
+      name: device_info_plus
+      sha256: a7fd703482b391a87d60b6061d04dfdeab07826b96f9abd8f5ed98068acc0074
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.1.2"
+  device_info_plus_platform_interface:
+    dependency: transitive
+    description:
+      name: device_info_plus_platform_interface
+      sha256: "282d3cf731045a2feb66abfe61bbc40870ae50a3ed10a4d3d217556c35c8c2ba"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.1"
   fake_async:
     dependency: transitive
     description:
@@ -308,18 +324,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7f0df31977cb2c0b88585095d168e689669a2cc9b97c309665e3386f3e9d341a"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.4"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "06e98f569d004c1315b991ded39924b21af84cf14cc94791b8aea337d25b57f8"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.3"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -356,18 +372,18 @@ packages:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: "0e0a020085b65b6083975e499759762399b4475f766c21668c4ecca34ea74e5a"
+      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
       url: "https://pub.dev"
     source: hosted
-    version: "0.8.0"
+    version: "0.11.1"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: "7687075e408b093f36e6bbf6c91878cc0d4cd10f409506f7bc996f68220b9136"
+      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.15.0"
   mime:
     dependency: transitive
     description:
@@ -396,18 +412,18 @@ packages:
     dependency: "direct main"
     description:
       name: package_info_plus
-      sha256: cb44f49b6e690fa766f023d5b22cac6b9affe741dd792b6ac7ad4fabe0d7b097
+      sha256: a75164ade98cb7d24cfd0a13c6408927c6b217fa60dee5a7ff5c116a58f28918
       url: "https://pub.dev"
     source: hosted
-    version: "6.0.0"
+    version: "8.0.2"
   package_info_plus_platform_interface:
     dependency: transitive
     description:
       name: package_info_plus_platform_interface
-      sha256: "9bc8ba46813a4cc42c66ab781470711781940780fd8beddd0c3da62506d3a6c6"
+      sha256: ac1f4a4847f1ade8e6a87d1f39f5d7c67490738642e2542f559ec38c37489a66
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   path:
     dependency: transitive
     description:
@@ -529,10 +545,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "9955ae474176f7ac8ee4e989dadfb411a58c30415bcfb648fa04b2b8a03afa7f"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.0"
+    version: "0.7.2"
   timing:
     dependency: transitive
     description:
@@ -569,10 +585,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "3923c89304b715fb1eb6423f017651664a03bf5f4b29983627c4da791f74a4ec"
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.dev"
     source: hosted
-    version: "14.2.1"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:
@@ -605,6 +621,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.4.0"
+  win32_registry:
+    dependency: transitive
+    description:
+      name: win32_registry
+      sha256: "10589e0d7f4e053f2c61023a31c9ce01146656a70b7b7f0828c0b46d7da2a9bb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.3"
   yaml:
     dependency: transitive
     description:

--- a/packages/rum_sdk/pubspec.yaml
+++ b/packages/rum_sdk/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   package_info_plus: ^8.0.1
   uuid: ^4.1.0
   intl: ^0.19.0
+  device_info_plus: ^10.1.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
This PR updates some Faro APIs. More specifically it does:

- add missing `timestamp` in Measurement
- renames attributes in `view_changed`. Adds `fromView` and renames `route` to `toView`
- adds `app_lifecycle_changed` events
- adds "real" device info meta data into session